### PR TITLE
Conditionally improve performance of `is_active_for_user`

### DIFF
--- a/waffle/models.py
+++ b/waffle/models.py
@@ -377,9 +377,10 @@ class AbstractUserFlag(AbstractBaseFlag):
 
         if hasattr(user, 'groups'):
             group_ids = self._get_group_ids()
-            user_groups = set(user.groups.all().values_list('pk', flat=True))
-            if group_ids.intersection(user_groups):
-                return True
+            if group_ids:
+                user_groups = set(user.groups.all().values_list('pk', flat=True))
+                if group_ids.intersection(user_groups):
+                    return True
 
         return None
 


### PR DESCRIPTION
`is_active_for_user` will fetch all groups for a user even if there are no group ids (meaning that the user's groups are pointless).  This commit changes that.  The final result of is_active_for_user should never change, but this improves post-cache per-request performance when checking a large number of Flag enrollments